### PR TITLE
add ability to create global read-only role

### DIFF
--- a/server-spi/src/main/java/org/keycloak/models/RoleModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/RoleModel.java
@@ -27,8 +27,8 @@ public interface RoleModel {
 
     // READ-ONLY ROLE RELATED ATTRIBUTES
 
-    String READ_ONLY_ROLE_ATTRIBUTE = "read.only.role";
-    String READ_ONLY_ROLE_REALMS_ATTRIBUTE = "read.only.role.realms";
+    String READ_ONLY_ROLE_ATTRIBUTE = "read.only";
+    String READ_ONLY_ROLE_REALMS_ATTRIBUTE = "read.only.explicit.realms";
 
     String getName();
 

--- a/server-spi/src/main/java/org/keycloak/models/RoleModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/RoleModel.java
@@ -17,16 +17,19 @@
 
 package org.keycloak.models;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
 public interface RoleModel {
+
+    // READ-ONLY ROLE RELATED ATTRIBUTES
+
+    String READ_ONLY_ROLE_ATTRIBUTE = "read.only.role";
+    String READ_ONLY_ROLE_REALMS_ATTRIBUTE = "read.only.role.realms";
+
     String getName();
 
     String getDescription();
@@ -64,4 +67,22 @@ public interface RoleModel {
     List<String> getAttribute(String name);
 
     Map<String, List<String>> getAttributes();
+
+    default boolean isReadOnly() {
+        List<String> readOnlyRoleAttribute = getAttribute(READ_ONLY_ROLE_ATTRIBUTE);
+        if (readOnlyRoleAttribute != null && readOnlyRoleAttribute.size() > 0) {
+            return Boolean.parseBoolean(readOnlyRoleAttribute.get(0));
+        }
+        return Boolean.FALSE;
+    }
+
+    default String[] getReadOnlyRoleRealms() {
+        List<String> multiTenantAttributes = getAttribute(READ_ONLY_ROLE_REALMS_ATTRIBUTE);
+        if (multiTenantAttributes != null && multiTenantAttributes.size() > 0) {
+            String[] splitter = multiTenantAttributes.get(0).split(",");
+            Arrays.stream(splitter).map(String::trim).toArray(unused -> splitter);
+            return splitter;
+        }
+        return new String[0];
+    }
 }

--- a/server-spi/src/main/java/org/keycloak/models/RoleModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/RoleModel.java
@@ -69,9 +69,9 @@ public interface RoleModel {
     Map<String, List<String>> getAttributes();
 
     default boolean isReadOnly() {
-        List<String> readOnlyRoleAttribute = getAttribute(READ_ONLY_ROLE_ATTRIBUTE);
-        if (readOnlyRoleAttribute != null && readOnlyRoleAttribute.size() > 0) {
-            return Boolean.parseBoolean(readOnlyRoleAttribute.get(0));
+        String readOnlyRoleAttribute = getFirstAttribute(READ_ONLY_ROLE_ATTRIBUTE);
+        if (readOnlyRoleAttribute != null) {
+            return Boolean.parseBoolean(readOnlyRoleAttribute);
         }
         return Boolean.FALSE;
     }

--- a/services/src/main/java/org/keycloak/services/managers/RealmManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/RealmManager.java
@@ -779,7 +779,6 @@ public class RealmManager {
         RealmModel adminRealm = model.getRealm(Config.getAdminRealm());
 
         // get all readonly admin realm roles
-        //List<ClientModel> readonlyRoles = session.clientStorageManager().getClientsByAttribute(adminRealm, ClientModel.MULTI_TENANT, TRUE.toString());
         RoleModel[] readonlyRoles = model.getRealmRoles(adminRealm)
                 .stream().filter(RoleModel::isReadOnly)
                 .toArray(RoleModel[]::new);
@@ -826,7 +825,6 @@ public class RealmManager {
         }
 
     }
-
 
     private void fireRealmPostCreate(RealmModel realm) {
         session.getKeycloakSessionFactory().publish(new RealmModel.RealmPostCreateEvent() {

--- a/services/src/main/java/org/keycloak/services/managers/RealmManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/RealmManager.java
@@ -34,10 +34,8 @@ import org.keycloak.sessions.AuthenticationSessionProvider;
 import org.keycloak.storage.UserStorageProviderModel;
 import org.keycloak.utils.ReservedCharValidator;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
+import java.util.*;
+import java.util.stream.Stream;
 
 import static java.lang.Boolean.TRUE;
 
@@ -104,6 +102,9 @@ public class RealmManager {
 
         // MULTI_TENANT CLIENT
         setupMultiTenantClientRegistrations(realm);
+
+        // READONLY_ROLE
+        setupReadonlyRolesRegistrations(realm);
 
         fireRealmPostCreate(realm);
 
@@ -598,6 +599,8 @@ public class RealmManager {
 
         setupMultiTenantClientRegistrations(realm);
 
+        setupReadonlyRolesRegistrations(realm);
+
         fireRealmPostCreate(realm);
 
         return realm;
@@ -767,6 +770,63 @@ public class RealmManager {
             }
         }
     }
+
+    private void setupReadonlyRolesRegistrations(RealmModel realm) {
+        // skip for admin (master) realm
+        if (Config.getAdminRealm().equals(realm.getId())) return;
+
+        // fetch readonly roles from master
+        RealmModel adminRealm = model.getRealm(Config.getAdminRealm());
+
+        // get all readonly admin realm roles
+        //List<ClientModel> readonlyRoles = session.clientStorageManager().getClientsByAttribute(adminRealm, ClientModel.MULTI_TENANT, TRUE.toString());
+        RoleModel[] readonlyRoles = model.getRealmRoles(adminRealm)
+                .stream().filter(RoleModel::isReadOnly)
+                .toArray(RoleModel[]::new);
+
+        if (readonlyRoles.length == 0) return; // no readonly roles in master!
+
+        String[] viewRoles = Arrays.stream(AdminRoles.ALL_REALM_ROLES)
+                .filter(r -> r.startsWith("view-"))
+                .toArray(String[]::new);
+
+        String[] readOnlyRoles = Stream.of(viewRoles, AdminRoles.ALL_QUERY_ROLES)
+                .flatMap(Stream::of)
+                .toArray(String[]::new);
+
+        // find this realm master admin app by name "{realmName}-realm"
+        String masterAdminAppName = realm.getName() + "-realm";
+        ClientModel masterAdminApp = adminRealm.getClientByClientId(masterAdminAppName);
+
+        for (RoleModel readonlyRole : readonlyRoles) {
+
+            String[] explicitRealmsFilter = readonlyRole.getReadOnlyRoleRealms();
+            //boolean doFilter = explicitRealmsFilter.length > 0;
+            boolean doFilter = Boolean.FALSE; //disabling realm filter-out functionality!
+
+            // filter out for this role if filter provided
+            if (doFilter && Arrays.stream(explicitRealmsFilter).noneMatch(r -> r.equals(realm.getName()))) {
+                // filter-out this realm !
+                continue;
+            }
+
+            for (String roleName : readOnlyRoles) {
+                // find the appropriate role from master admin app
+                RoleModel foundRole = masterAdminApp.getRole(roleName);
+
+                if (foundRole == null) {
+                    logger.errorf("read-only role registration -> master app role with name '%s' not found in app '%s'!", roleName, masterAdminAppName);
+                    continue;
+                }
+
+                // and composite to the readonly role
+                readonlyRole.addCompositeRole(foundRole);
+            }
+
+        }
+
+    }
+
 
     private void fireRealmPostCreate(RealmModel realm) {
         session.getKeycloakSessionFactory().publish(new RealmModel.RealmPostCreateEvent() {

--- a/services/src/main/java/org/keycloak/services/resources/admin/RoleContainerResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RoleContainerResource.java
@@ -148,6 +148,8 @@ public class RoleContainerResource extends RoleResource {
 
             // readonly-role related registrations
             if (!role.isClientRole() && isReadOnly(rep)) {
+                role.setSingleAttribute(READ_ONLY_ROLE_ATTRIBUTE, Boolean.TRUE.toString());
+
                 setupReadonlyRoleRegistrations(role, rep);
             }
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/RoleResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RoleResource.java
@@ -17,22 +17,22 @@
 
 package org.keycloak.services.resources.admin;
 
+import org.apache.commons.lang.ArrayUtils;
+import org.keycloak.Config;
 import org.keycloak.events.admin.OperationType;
 import org.keycloak.events.admin.ResourceType;
-import org.keycloak.models.ClientModel;
-import org.keycloak.models.RealmModel;
-import org.keycloak.models.RoleModel;
+import org.keycloak.models.*;
 import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.services.resources.admin.permissions.AdminPermissionEvaluator;
 
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.UriInfo;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+import java.util.stream.Stream;
+
+import static org.keycloak.models.RoleModel.READ_ONLY_ROLE_ATTRIBUTE;
+import static org.keycloak.models.RoleModel.READ_ONLY_ROLE_REALMS_ATTRIBUTE;
 
 /**
  * @resource Roles
@@ -142,4 +142,75 @@ public abstract class RoleResource {
 
         adminEvent.operation(OperationType.DELETE).resourcePath(uriInfo).representation(roles).success();
     }
+
+    protected void setupReadonlyRoleRegistrations(KeycloakSession session, RoleModel role, RoleRepresentation rep) {
+        RealmModel adminRealm = session.realms().getRealm(Config.getAdminRealm());
+
+        List<RealmModel> allRealms = session.realms().getRealms();
+
+        String[] viewRoles = Arrays.stream(AdminRoles.ALL_REALM_ROLES)
+                .filter(r -> r.startsWith("view-"))
+                .toArray(String[]::new);
+
+        String[] readOnlyRoles = Stream.of(viewRoles, AdminRoles.ALL_QUERY_ROLES)
+                .flatMap(Stream::of)
+                .toArray(String[]::new);
+
+        String[] explicitRealmsFilter = getReadOnlyRoleRealmsFilter(rep);
+        //boolean doFilter = explicitRealmsFilter.length > 0;
+        boolean doFilter = Boolean.FALSE; //disabling realm filter-out functionality!
+
+        for (RealmModel realmElement : allRealms) {
+            // exclude 'master'
+            if (realmElement.getName().equals(Config.getAdminRealm()))
+                continue;
+
+            // filter out if filter provided
+            if (doFilter && Arrays.stream(explicitRealmsFilter).noneMatch(r -> r.equals(realmElement.getName()))) {
+                // filter-out this realm !
+                continue;
+            }
+
+            // find master admin apps by name "{realmName}-realm"
+            String masterAdminAppName = realmElement.getName() + "-realm";
+            ClientModel masterAdminApp = adminRealm.getClientByClientId(masterAdminAppName);
+
+            for (String roleName : readOnlyRoles) {
+                // find the appropriate role from master admin app
+                RoleModel foundRole = masterAdminApp.getRole(roleName);
+
+                if (foundRole == null) {
+                    //logger.errorf("read-only role registration -> master app role with name '%s' not found in app '%s'!", roleName, masterAdminAppName);
+                    continue;
+                }
+
+                // and composite to the readonly role
+                role.addCompositeRole(foundRole);
+            }
+        }
+    }
+
+    protected boolean isReadOnly(RoleRepresentation rep) {
+        Map<String, List<String>> attributes = rep.getAttributes();
+        if (attributes == null || !attributes.containsKey(READ_ONLY_ROLE_ATTRIBUTE)) return Boolean.FALSE;
+
+        String[] readOnlyRoleAttribute = attributes.get(READ_ONLY_ROLE_ATTRIBUTE).toArray(new String[0]);
+        if (ArrayUtils.isNotEmpty(readOnlyRoleAttribute)) {
+            return Boolean.parseBoolean(readOnlyRoleAttribute[0]);
+        }
+        return Boolean.FALSE;
+    }
+
+    protected String[] getReadOnlyRoleRealmsFilter(RoleRepresentation rep) {
+        Map<String, List<String>> attributes = rep.getAttributes();
+        if (attributes == null || !attributes.containsKey(READ_ONLY_ROLE_REALMS_ATTRIBUTE))
+            return ArrayUtils.EMPTY_STRING_ARRAY;
+
+        String[] readOnlyRoleRealms = attributes.get(READ_ONLY_ROLE_REALMS_ATTRIBUTE).toArray(new String[0]);
+        if (ArrayUtils.isNotEmpty(readOnlyRoleRealms)) {
+            return readOnlyRoleRealms;
+        }
+        return ArrayUtils.EMPTY_STRING_ARRAY;
+    }
+
 }

--- a/services/src/main/java/org/keycloak/services/resources/admin/RoleResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RoleResource.java
@@ -194,7 +194,10 @@ public abstract class RoleResource {
         Map<String, List<String>> attributes = rep.getAttributes();
         if (attributes == null || !attributes.containsKey(READ_ONLY_ROLE_ATTRIBUTE)) return Boolean.FALSE;
 
-        String[] readOnlyRoleAttribute = attributes.get(READ_ONLY_ROLE_ATTRIBUTE).toArray(new String[0]);
+        List<String> readonlyAttr = attributes.get(READ_ONLY_ROLE_ATTRIBUTE);
+        if (readonlyAttr == null) return Boolean.FALSE;
+
+        String[] readOnlyRoleAttribute = readonlyAttr.toArray(new String[0]);
         if (ArrayUtils.isNotEmpty(readOnlyRoleAttribute)) {
             return Boolean.parseBoolean(readOnlyRoleAttribute[0]);
         }
@@ -206,7 +209,10 @@ public abstract class RoleResource {
         if (attributes == null || !attributes.containsKey(READ_ONLY_ROLE_REALMS_ATTRIBUTE))
             return ArrayUtils.EMPTY_STRING_ARRAY;
 
-        String[] readOnlyRoleRealms = attributes.get(READ_ONLY_ROLE_REALMS_ATTRIBUTE).toArray(new String[0]);
+        List<String> filterRealms = attributes.get(READ_ONLY_ROLE_REALMS_ATTRIBUTE);
+        if (filterRealms == null) return ArrayUtils.EMPTY_STRING_ARRAY;
+
+        String[] readOnlyRoleRealms = filterRealms.toArray(new String[0]);
         if (ArrayUtils.isNotEmpty(readOnlyRoleRealms)) {
             return readOnlyRoleRealms;
         }


### PR DESCRIPTION
**read-only role**: 
	master realm role composed of all read-only roles from every user realm in the instance.

creation: 
	createRole admin method payload extended with attribute 'read.only'

payload example:
{
	"name":"read-only-role",
	"description":"role that reads them all",
	"attributes": {
		"read.only":["true"]
	}
}