### PR TITLE
Add multi-tenant client instance resource-server auth defaults

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
@@ -924,7 +924,7 @@ public class ModelToRepresentation {
         
         if (allFields) {
             representation.setResourcesData(policy.getResources().stream().map(
-                    resource -> toRepresentation(resource, resource.getResourceServer(), authorization, true)).collect(Collectors.toSet()));
+                    resource -> toRepresentation(resource, resource.getResourceServer(), authorization)).collect(Collectors.toSet()));
             representation.setScopesData(policy.getScopes().stream().map(
                     resource -> toRepresentation(resource)).collect(Collectors.toSet()));
         }
@@ -952,6 +952,7 @@ public class ModelToRepresentation {
         owner.setId(model.getOwner());
 
         KeycloakSession keycloakSession = authorization.getKeycloakSession();
+
         RealmModel realm = authorization.getRealm();
 
         if (owner.getId().equals(resourceServer.getId())) {

--- a/services/src/main/java/org/keycloak/authorization/admin/PolicyService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/PolicyService.java
@@ -17,26 +17,6 @@
  */
 package org.keycloak.authorization.admin;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-
 import org.jboss.resteasy.annotations.cache.NoCache;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.keycloak.authorization.AuthorizationProvider;
@@ -59,9 +39,21 @@ import org.keycloak.representations.idm.authorization.AbstractPolicyRepresentati
 import org.keycloak.representations.idm.authorization.PolicyProviderRepresentation;
 import org.keycloak.representations.idm.authorization.PolicyRepresentation;
 import org.keycloak.services.ErrorResponseException;
-import org.keycloak.services.resources.admin.permissions.AdminPermissionEvaluator;
 import org.keycloak.services.resources.admin.AdminEventBuilder;
+import org.keycloak.services.resources.admin.permissions.AdminPermissionEvaluator;
 import org.keycloak.util.JsonSerialization;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>

--- a/services/src/main/java/org/keycloak/authorization/admin/ResourceServerService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/ResourceServerService.java
@@ -39,6 +39,7 @@ import org.keycloak.events.admin.ResourceType;
 import org.keycloak.exportimport.util.ExportUtils;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.models.utils.RepresentationToModel;
@@ -85,7 +86,8 @@ public class ResourceServerService {
 
         if (this.resourceServer == null) {
             this.resourceServer = RepresentationToModel.createResourceServer(client, session, true);
-            createDefaultPermission(createDefaultResource(), createDefaultPolicy());
+            ResourceRepresentation defaultResource = createDefaultResource();
+            createDefaultPermission(defaultResource, createDefaultPolicy());
             audit(OperationType.CREATE, session.getContext().getUri(), newClient);
         }
 

--- a/services/src/main/java/org/keycloak/authorization/admin/ResourceSetService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/ResourceSetService.java
@@ -128,7 +128,9 @@ public class ResourceSetService {
             throw new ErrorResponseException(OAuthErrorException.INVALID_REQUEST, "Resource with name [" + resource.getName() + "] already exists.", Status.CONFLICT);
         }
 
-        return toRepresentation(toModel(resource, this.resourceServer, authorization), resourceServer, authorization);
+        Resource model = toModel(resource, this.resourceServer, authorization);
+
+        return toRepresentation(model, resourceServer, authorization);
     }
 
     @Path("{id}")

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientsResource.java
@@ -324,11 +324,11 @@ public class ClientsResource {
 
     public static class RealmWithClientUidRepresentation implements Serializable {
         private String realmName;
-        private String clientUid;
+        private String clientGuid;
 
-        private RealmWithClientUidRepresentation(String realmName, String clientUid){
+        private RealmWithClientUidRepresentation(String realmName, String clientGuid){
             this.realmName = realmName;
-            this.clientUid = clientUid;
+            this.clientGuid = clientGuid;
         }
 
         public static RealmWithClientUidRepresentation asRepresentation(String realmName, String clientUid){
@@ -343,33 +343,12 @@ public class ClientsResource {
             this.realmName = realmName;
         }
 
-        public String getClientUid() {
-            return clientUid;
+        public String getClientGuid() {
+            return clientGuid;
         }
 
-        public void setClientUid(String clientUid) {
-            this.clientUid = clientUid;
+        public void setClientGuid(String clientGuid) {
+            this.clientGuid = clientGuid;
         }
     }
-
-//    public class RealmWithClientUidRepresentation implements Serializable {
-//        private String realmName;
-//        private String clientUid;
-//
-//        public String getRealmName() {
-//            return realmName;
-//        }
-//
-//        public void setRealmName(String realmName) {
-//            this.realmName = realmName;
-//        }
-//
-//        public String getClientUid() {
-//            return clientUid;
-//        }
-//
-//        public void setClientUid(String clientUid) {
-//            this.clientUid = clientUid;
-//        }
-//    }
 }

--- a/services/src/main/java/org/keycloak/services/util/ResourceServerDefaultPermissionCreator.java
+++ b/services/src/main/java/org/keycloak/services/util/ResourceServerDefaultPermissionCreator.java
@@ -1,0 +1,122 @@
+package org.keycloak.services.util;
+
+import org.keycloak.OAuthErrorException;
+import org.keycloak.authorization.AuthorizationProvider;
+import org.keycloak.authorization.model.Policy;
+import org.keycloak.authorization.model.Resource;
+import org.keycloak.authorization.model.ResourceServer;
+import org.keycloak.authorization.store.PolicyStore;
+import org.keycloak.authorization.store.StoreFactory;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.representations.idm.authorization.*;
+import org.keycloak.services.ErrorResponseException;
+
+import javax.ws.rs.core.Response;
+import java.util.Collections;
+import java.util.HashMap;
+
+import static org.keycloak.models.utils.RepresentationToModel.toModel;
+
+public class ResourceServerDefaultPermissionCreator {
+
+    protected KeycloakSession session;
+    protected AuthorizationProvider authorization;
+    protected ResourceServer resourceServer;
+
+    public ResourceServerDefaultPermissionCreator(KeycloakSession session, AuthorizationProvider authorization, ResourceServer resourceServer) {
+        this.session = session;
+        this.authorization = authorization;
+        this.resourceServer = resourceServer;
+    }
+
+    public void create(ClientModel client){
+        createDefaultPermission(createDefaultResource(client), createDefaultPolicy());
+    }
+
+    private PolicyRepresentation createDefaultPolicy() {
+        PolicyRepresentation defaultPolicy = new PolicyRepresentation();
+
+        defaultPolicy.setName("Default Policy");
+        defaultPolicy.setDescription("A policy that grants access only for users within this realm");
+        defaultPolicy.setType("js");
+        defaultPolicy.setDecisionStrategy(DecisionStrategy.AFFIRMATIVE);
+        defaultPolicy.setLogic(Logic.POSITIVE);
+
+        HashMap<String, String> defaultPolicyConfig = new HashMap<>();
+
+        defaultPolicyConfig.put("code", "// by default, grants any permission associated with this policy\n$evaluation.grant();\n");
+
+        defaultPolicy.setConfig(defaultPolicyConfig);
+
+        session.setAttribute("ALLOW_CREATE_POLICY", true);
+
+        PolicyStore policyStore = authorization.getStoreFactory().getPolicyStore();
+
+        // validate existing:
+        Policy existing = policyStore.findByName(defaultPolicy.getName(), resourceServer.getId());
+
+        if (existing != null) {
+            throw new ErrorResponseException("Policy with name [" + defaultPolicy.getName() + "] already exists", "Conflicting policy", Response.Status.CONFLICT);
+        }
+
+        // persist:
+        policyStore.create(defaultPolicy, resourceServer);
+
+        return defaultPolicy;
+    }
+
+    private ResourceRepresentation createDefaultResource(ClientModel client) {
+        ResourceRepresentation defaultResource = new ResourceRepresentation();
+
+        defaultResource.setName("Default Resource");
+        defaultResource.setUris(Collections.singleton("/*"));
+        defaultResource.setType("urn:" + client.getClientId() + ":resources:default");
+
+        ResourceOwnerRepresentation owner = new ResourceOwnerRepresentation();
+        owner.setId(resourceServer.getId());
+        defaultResource.setOwner(owner);
+
+        String ownerId = owner.getId();
+
+        StoreFactory storeFactory = authorization.getStoreFactory();
+
+        // validate already existing:
+        Resource existingResource = storeFactory.getResourceStore().findByName(defaultResource.getName(), ownerId, resourceServer.getId());
+
+        if (existingResource != null) {
+            throw new ErrorResponseException(OAuthErrorException.INVALID_REQUEST, "Resource with name [" + defaultResource.getName() + "] already exists.", Response.Status.CONFLICT);
+        }
+
+        // persist:
+        toModel(defaultResource, resourceServer, authorization);
+
+        return defaultResource;
+    }
+
+    private void createDefaultPermission(ResourceRepresentation resource, PolicyRepresentation policy) {
+        ResourcePermissionRepresentation defaultPermission = new ResourcePermissionRepresentation();
+
+        defaultPermission.setName("Default Permission");
+        defaultPermission.setDescription("A permission that applies to the default resource type");
+        defaultPermission.setDecisionStrategy(DecisionStrategy.UNANIMOUS);
+        defaultPermission.setLogic(Logic.POSITIVE);
+
+        defaultPermission.setResourceType(resource.getType());
+        defaultPermission.addPolicy(policy.getName());
+
+        PolicyStore policyStore = authorization.getStoreFactory().getPolicyStore();
+
+        // validate already existing:
+        Policy existing = policyStore.findByName(defaultPermission.getName(), resourceServer.getId());
+
+        if (existing != null) {
+            throw new ErrorResponseException("Policy with name [" + defaultPermission.getName() + "] already exists", "Conflicting policy", Response.Status.CONFLICT);
+        }
+
+        // persist:
+        policyStore.create(defaultPermission, resourceServer);
+
+        return;
+    }
+}


### PR DESCRIPTION
Create Multi-tenant Client and Create Realm methods related updates to add missing default resource-server authorization objects. Added is also a Data Migration to align existing mt-clients.
